### PR TITLE
style: :lipstick: revise landing page so survey is bigger and FAQ collapse works

### DIFF
--- a/index.qmd
+++ b/index.qmd
@@ -2,53 +2,104 @@
 title: "National afprøvning af glukosesensorer til type 2-diabetes: Afprøvning af sensorer i almen praksis"
 ---
 
-**Om Projektet**
-Sammen med ca. 50 klinikker fra Region Midtjylland, Region Syddanmark og Region Sjælland afprøvers brugen af Continuous Glucose Monitoring (CGM) sensorer til patienter med type 2-diabetes (T2D), der bruger insulin og har HbA1c > 53 mmol/mol. 
+## Om Projektet
 
-Formålet med projektet er at afdække værdien af at anvende blodsukkersensorer som hjemmemålingsudstyr i almen praksis, med fokus på at forbedre blodsukkerreguleringen, styrke patienternes egenomsorg, samt øge tryghed og tilfredshed med behandlingen. Derudover undersøges, om brugen af hjemmemålingsudstyr kan reducere behovet for fysiske kontakter mellem patienter og sundhedspersonale.
+Sammen med ca. 50 klinikker fra Region Midtjylland, Region Syddanmark og
+Region Sjælland afprøvers brugen af Continuous Glucose Monitoring (CGM)
+sensorer til patienter med type 2-diabetes (T2D), der bruger insulin og
+har HbA1c \> 53 mmol/mol.
 
-Dette projekt sigter mod at forbedre behandlingen af type 2-diabetes ved at integrere ny teknologi i den daglige kliniske praksis.
+Formålet med projektet er at afdække værdien af at anvende
+blodsukkersensorer som hjemmemålingsudstyr i almen praksis, med fokus på
+at forbedre blodsukkerreguleringen, styrke patienternes egenomsorg, samt
+øge tryghed og tilfredshed med behandlingen. Derudover undersøges, om
+brugen af hjemmemålingsudstyr kan reducere behovet for fysiske kontakter
+mellem patienter og sundhedspersonale.
 
-**Fordele ved at deltage**
+Dette projekt sigter mod at forbedre behandlingen af type 2-diabetes ved
+at integrere ny teknologi i den daglige kliniske praksis.
+
+### Fordele ved at deltage
+
 Som deltager i projektet får din klinik:
 
--	Gratis glukosesensorer i op til 12 måneder til jeres patienter med T2D, der bruger insulin.
--	Økonomisk kompensation for ekstra administrative opgaver og dokumentation.
--	Mulighed for at være frontløber i anvendelsen af ny teknologi til diabetesbehandling.
+-   Gratis glukosesensorer i op til 12 måneder til jeres patienter med
+    T2D, der bruger insulin.
+-   Økonomisk kompensation for ekstra administrative opgaver og
+    dokumentation.
+-   Mulighed for at være frontløber i anvendelsen af ny teknologi til
+    diabetesbehandling.
 
-**Rekruttering og registrering:**
-- Klinikken finder målgruppen ved at trække en liste over T2D patienter med HbA1c >53, som bruger insulin. Listen suppleres med patienter med HbA1c > 53, der kan have gavn af at starte insulinbehandling.
--	Den praktiserende læge vurderer i samarbejde med patienten, om patienten er egnet til at deltage i projektet, baseret på definerede inklusions- og eksklusionskriterier.
--	Før videregivelse af oplysninger om patienter der ønsker at deltage, indhentes mundtligt samtykke til videregivelse af kontaktoplysninger. Samtykke noteres i patientens journal.
--	Det skal registreres, hvor mange patienter der er i målgruppen, hvor mange der efter vurdering af inklusions- og eksklusionskriterier bliver inviteret, og hvor mange der slutteligt siger ja til at deltage.
--	Klinikken skal sikre måling af HbA1c-niveauer ved baseline samt ved 6 og 12 måneder samt registrere behandlingsmål.
--	Data overføres til SDCA via REDCap ved projektets afslutning samt ved AGP-rapporter der sendes via sikker post.
+### Rekruttering og registrering:
 
-**Sådan anvendes sensorerne:**
--	CGM-sensorer anvendes kontinuerligt, indtil behandlingsmålet (HbA1c < 53 eller individuelt fastsat niveau) er opnået. Dog minimum 6 måneder.
--	Efter opnåelse af behandlingsmålet anvendes CGM-sensoren fortsat i to uger før en aftalt konsultation.
--	En patient kan maksimalt anvende en CGM-sensor i 12 måneder.
+-   Klinikken finder målgruppen ved at trække en liste over T2D
+    patienter med HbA1c \>53, som bruger insulin. Listen suppleres med
+    patienter med HbA1c \> 53, der kan have gavn af at starte
+    insulinbehandling.
+-   Den praktiserende læge vurderer i samarbejde med patienten, om
+    patienten er egnet til at deltage i projektet, baseret på definerede
+    inklusions- og eksklusionskriterier.
+-   Før videregivelse af oplysninger om patienter der ønsker at deltage,
+    indhentes mundtligt samtykke til videregivelse af
+    kontaktoplysninger. Samtykke noteres i patientens journal.
+-   Det skal registreres, hvor mange patienter der er i målgruppen, hvor
+    mange der efter vurdering af inklusions- og eksklusionskriterier
+    bliver inviteret, og hvor mange der slutteligt siger ja til at
+    deltage.
+-   Klinikken skal sikre måling af HbA1c-niveauer ved baseline samt ved
+    6 og 12 måneder samt registrere behandlingsmål.
+-   Data overføres til SDCA via REDCap ved projektets afslutning samt
+    ved AGP-rapporter der sendes via sikker post.
 
-**Rekruttering og registrering**
--	Klinikken finder målgruppen ved at trække en liste over T2D patienter med HbA1c >53, som bruger insulin. Listen suppleres med patienter med HbA1c > 53, der kan have gavn af at starte insulinbehandling.
--	Den praktiserende læge vurderer i samarbejde med patienten, om patienten er egnet til at deltage i projektet, baseret på definerede inklusions- og eksklusionskriterier.
--	Før videregivelse af oplysninger om patienter der ønsker at deltage, indhentes mundtligt samtykke til videregivelse af kontaktoplysninger. Samtykke noteres i patientens journal.
--	Det skal registreres, hvor mange patienter der er i målgruppen, hvor mange der efter vurdering af inklusions- og eksklusionskriterier bliver inviteret, og hvor mange der slutteligt siger ja til at deltage.
--	Klinikken skal sikre måling af HbA1c-niveauer ved baseline samt ved 6 og 12 måneder samt registrere behandlingsmål.
--	Data overføres til SDCA via REDCap ved projektets afslutning samt ved AGP-rapporter der sendes via sikker post.
+### Sådan anvendes sensorerne:
 
-**Sådan anvendes sensorerne**
--	CGM-sensorer anvendes kontinuerligt, indtil behandlingsmålet (HbA1c < 53 eller individuelt fastsat niveau) er opnået. Dog minimum 6 måneder.
--	Efter opnåelse af behandlingsmålet anvendes CGM-sensoren fortsat i to uger før en aftalt konsultation.
--	En patient kan maksimalt anvende en CGM-sensor i 12 måneder.
+-   CGM-sensorer anvendes kontinuerligt, indtil behandlingsmålet (HbA1c
+    \< 53 eller individuelt fastsat niveau) er opnået. Dog minimum 6
+    måneder.
+-   Efter opnåelse af behandlingsmålet anvendes CGM-sensoren fortsat i
+    to uger før en aftalt konsultation.
+-   En patient kan maksimalt anvende en CGM-sensor i 12 måneder.
 
-**Tilmelding af lægeklinik**
-Der er plads til at ca. 50 lægeklinikker kan deltage i projektet i alt i Region Midtjylland, Region Syddanmark og Region Sjælland. Tilmelding sker efter først-til-mølle-princippet. For at sikre jeres plads, tilmeld jer derfor introduktionsmødet så hurtigt som muligt.
+### Rekruttering og registrering
 
+-   Klinikken finder målgruppen ved at trække en liste over T2D
+    patienter med HbA1c \>53, som bruger insulin. Listen suppleres med
+    patienter med HbA1c \> 53, der kan have gavn af at starte
+    insulinbehandling.
+-   Den praktiserende læge vurderer i samarbejde med patienten, om
+    patienten er egnet til at deltage i projektet, baseret på definerede
+    inklusions- og eksklusionskriterier.
+-   Før videregivelse af oplysninger om patienter der ønsker at deltage,
+    indhentes mundtligt samtykke til videregivelse af
+    kontaktoplysninger. Samtykke noteres i patientens journal.
+-   Det skal registreres, hvor mange patienter der er i målgruppen, hvor
+    mange der efter vurdering af inklusions- og eksklusionskriterier
+    bliver inviteret, og hvor mange der slutteligt siger ja til at
+    deltage.
+-   Klinikken skal sikre måling af HbA1c-niveauer ved baseline samt ved
+    6 og 12 måneder samt registrere behandlingsmål.
+-   Data overføres til SDCA via REDCap ved projektets afslutning samt
+    ved AGP-rapporter der sendes via sikker post.
+
+### Sådan anvendes sensorerne
+
+-   CGM-sensorer anvendes kontinuerligt, indtil behandlingsmålet (HbA1c
+    \< 53 eller individuelt fastsat niveau) er opnået. Dog minimum 6
+    måneder.
+-   Efter opnåelse af behandlingsmålet anvendes CGM-sensoren fortsat i
+    to uger før en aftalt konsultation.
+-   En patient kan maksimalt anvende en CGM-sensor i 12 måneder.
+
+### Tilmelding af lægeklinik
+
+Der er plads til at ca. 50 lægeklinikker kan deltage i projektet i alt i
+Region Midtjylland, Region Syddanmark og Region Sjælland. Tilmelding
+sker efter først-til-mølle-princippet. For at sikre jeres plads, tilmeld
+jer derfor introduktionsmødet så hurtigt som muligt.
 
 ## Tilmelding
 
-<iframe src="https://www.survey-xact.dk/LinkCollector?key=NAF5AS23JP16">
+<iframe src="https://www.survey-xact.dk/LinkCollector?key=NAF5AS23JP16" width="100%" height="1000px" style="border: 6px solid black">
 
 </iframe>
 
@@ -59,63 +110,119 @@ Der er plads til at ca. 50 lægeklinikker kan deltage i projektet i alt i Region
 ## Ofte stillede spørgsmål
 
 <details>
-<summary>**1. Hvad er inklusions- og eksklusionskriterierne for patienter i projektet?**<summary>
 
-Svar: Patienter skal være over 18 år, have type 2-diabetes, HbA1c > 53 og bruge insulin eller have gavn af at starte behandling. Eksklusionskriterier inkluderer fx gravide, patienter der ikke har mulighed for at up-loade sensordata via deres telefon og patienter der fx bor på plejehjem/bosteder og ikke selv varetager insulinbehandlingen. Kriterierne vil blive præciseret ved introduktionsmødet.
+<summary>**1. Hvad er inklusions- og eksklusionskriterierne for
+patienter i projektet?**</summary>
+
+Svar: Patienter skal være over 18 år, have type 2-diabetes, HbA1c \> 53
+og bruge insulin eller have gavn af at starte behandling.
+Eksklusionskriterier inkluderer fx gravide, patienter der ikke har
+mulighed for at up-loade sensordata via deres telefon og patienter der
+fx bor på plejehjem/bosteder og ikke selv varetager insulinbehandlingen.
+Kriterierne vil blive præciseret ved introduktionsmødet.
+
 </details>
 
 <details>
-<summary>**2. Hvordan rekrutteres patienter til projektet?**<summary>
 
-Svar: Klinikken trækker en liste over patienter med HbA1c >53, der bruger insulin. Listen suppleres med patienter med HbA1c > 53, der kan have gavn af at starte insulinbehandling.
-Klinikken vurderer, ud fra in- og eksklusionskriterierne hvilke patienter der kunne have gavn af at afprøve CGM-sensoren. Klinikken kontakter patienterne og inviterer dem til deltagelse i afprøvningen. Der indhentes mundtligt samtykke til videregivelse af kontaktoplysninger, som noteres i patientens journal.
+<summary>**2. Hvordan rekrutteres patienter til projektet?**</summary>
+
+Svar: Klinikken trækker en liste over patienter med HbA1c \>53, der
+bruger insulin. Listen suppleres med patienter med HbA1c \> 53, der kan
+have gavn af at starte insulinbehandling. Klinikken vurderer, ud fra in-
+og eksklusionskriterierne hvilke patienter der kunne have gavn af at
+afprøve CGM-sensoren. Klinikken kontakter patienterne og inviterer dem
+til deltagelse i afprøvningen. Der indhentes mundtligt samtykke til
+videregivelse af kontaktoplysninger, som noteres i patientens journal.
+
 </details>
 
 <details>
-<summary>**3. Hvordan registreres og rapporteres data fra projektet?**<summary>
 
-Svar: Lægen skal sikre at behandlingsmål registreres i journalen og at der foretages måling af Hba1c til ca. tid 6 mdr. og tid 12 mdr. Ved projektets afslutning skal data videregives til SDCA via et patientspecifikt link til REDCap samt via AGP-rapporter, der sendes med sikker post.
+<summary>**3. Hvordan registreres og rapporteres data fra
+projektet?**</summary>
+
+Svar: Lægen skal sikre at behandlingsmål registreres i journalen og at
+der foretages måling af Hba1c til ca. tid 6 mdr. og tid 12 mdr. Ved
+projektets afslutning skal data videregives til SDCA via et
+patientspecifikt link til REDCap samt via AGP-rapporter, der sendes med
+sikker post.
+
 </details>
 
 <details>
-<summary>**4. Hvor meget tid kræver projektet af klinikken?**<summary>
 
-Svar: Tidsforbruget omfatter rekruttering af patienter, deltagelse i introduktionsmøde, samt dataregistrering og rapportering. Den præcise tidsramme afhænger af klinikkens størrelse og antallet af patienter.
+<summary>**4. Hvor meget tid kræver projektet af klinikken?**</summary>
+
+Svar: Tidsforbruget omfatter rekruttering af patienter, deltagelse i
+introduktionsmøde, samt dataregistrering og rapportering. Den præcise
+tidsramme afhænger af klinikkens størrelse og antallet af patienter.
+
 </details>
 
 <details>
-<summary>**5. Hvad sker der, hvis vi ikke når at rekruttere nok patienter?**<summary>
 
-Svar: Hvis klinikken ikke når at rekruttere det ønskede antal patienter, vil der være en venteliste. Klinikker på venteliste i den enkelte region kan dermed få mulighed for at deltage, hvis andre klinikker i regionen ikke når deres mål.
+<summary>**5. Hvad sker der, hvis vi ikke når at rekruttere nok
+patienter?**</summary>
+
+Svar: Hvis klinikken ikke når at rekruttere det ønskede antal patienter,
+vil der være en venteliste. Klinikker på venteliste i den enkelte region
+kan dermed få mulighed for at deltage, hvis andre klinikker i regionen
+ikke når deres mål.
+
 </details>
 
 <details>
-<summary>**6. Hvordan håndteres tekniske problemer med CGM-sensorerne?**<summary>
 
-Svar: Teknisk support vil være tilgængelig gennem projektet. Klinikken vil få instruktioner om, hvordan man kontakter supportteamet ved eventuelle problemer med sensorerne.
+<summary>**6. Hvordan håndteres tekniske problemer med
+CGM-sensorerne?**</summary>
+
+Svar: Teknisk support vil være tilgængelig gennem projektet. Klinikken
+vil få instruktioner om, hvordan man kontakter supportteamet ved
+eventuelle problemer med sensorerne.
+
 </details>
 
 <details>
-<summary>**7. Er der nogen omkostninger for klinikken?**<summary>
 
-Svar: Der er ingen omkostninger for klinikken for selve CGM-sensorerne, og der vil blive givet økonomisk kompensation for ekstra administrative opgaver og dokumentation.
+<summary>**7. Er der nogen omkostninger for klinikken?**</summary>
+
+Svar: Der er ingen omkostninger for klinikken for selve CGM-sensorerne,
+og der vil blive givet økonomisk kompensation for ekstra administrative
+opgaver og dokumentation.
+
 </details>
 
 <details>
-<summary>**8. Hvordan vil økonomisk kompensation blive udbetalt?**<summary>
-</details>
 
-Svar: Økonomisk kompensation udbetales baseret på antallet af patienter, der deltager i projektet, og dækker tid til rekruttering og dataindsamling. Nærmere detaljer om udbetalingsproceduren vil blive givet i oplæringssmødet og i samarbejdskontrakten.
+<summary>**8. Hvordan vil økonomisk kompensation blive
+udbetalt?**</summary>
+
+Svar: Økonomisk kompensation udbetales baseret på antallet af patienter,
+der deltager i projektet, og dækker tid til rekruttering og
+dataindsamling. Nærmere detaljer om udbetalingsproceduren vil blive
+givet i oplæringssmødet og i samarbejdskontrakten.
+
 </details>
 
 <details>
-<summary>**9. Hvad sker der, når projektperioden er slut?**<summary>
 
-Svar: Når projektperioden er afsluttet, skal alle data overføres til SDCA via REDCap. Klinikkerne skal returnere eller destruere eventuelle resterende sensorer i henhold til de instruktioner, der gives ved projektets afslutning. 
+<summary>**9. Hvad sker der, når projektperioden er slut?**</summary>
+
+Svar: Når projektperioden er afsluttet, skal alle data overføres til
+SDCA via REDCap. Klinikkerne skal returnere eller destruere eventuelle
+resterende sensorer i henhold til de instruktioner, der gives ved
+projektets afslutning.
+
 </details>
 
 <details>
-<summary>**10. Hvordan kan projektkoordinatoren kontaktes, hvis vi har spørgsmål undervejs?**<summary>
 
-Svar: I kan kontakte projektkoordinator Tina Quist via e-mail på tina.quist@rm.dk eller telefonisk på 24 34 63 47. Tina er tilgængelig for at besvare spørgsmål og tilbyde støtte gennem hele projektet.
+<summary>**10. Hvordan kan projektkoordinatoren kontaktes, hvis vi har
+spørgsmål undervejs?**</summary>
+
+Svar: I kan kontakte projektkoordinator Tina Quist via e-mail på
+tina.quist\@rm.dk eller telefonisk på 24 34 63 47. Tina er tilgængelig
+for at besvare spørgsmål og tilbyde støtte gennem hele projektet.
+
 </details>


### PR DESCRIPTION
@TinaQuist I fixed some formatting issues with the website. When you write Markdown lists, like:

```
- item 1
- item 2
```

it needs to have an empty line above the list. So this will work:

```
Text header here

- item 1
- item 2
```

but this won't work:

```
Text header here
- Item 1
```

Also, I converted some bolded items into headers to split the text up a bit more nicely as well as made the survey form bigger and have a clear border around it to indicate it is a survey.

I will merge this in so you can see it on the website, but this is just to give you some explanation.