### PR TITLE
fix: :bug: correct URL link to video

### DIFF
--- a/index.qmd
+++ b/index.qmd
@@ -77,7 +77,7 @@ jer derfor oplæringssmødet så hurtigt som muligt.
 
 ## Erfaringer fra pilotprojekt
 
-{{< "https://region-midtjylland.23video.com/secret/107716498/60d4a696d545151884fcdb2d25f0f8fd">}}
+{{< video https://region-midtjylland.23video.com/v.ihtml/player.html?token=60d4a696d545151884fcdb2d25f0f8fd&showBrowse=0&showSharing=0&socialSharing=0&source=site&photo%5fid=107716498 >}}
 
 ## Ofte stillede spørgsmål
 


### PR DESCRIPTION
The "shortcode" (the stuff between the `{{< >}}`) for videos is `video URL`. And the URL needs to be *the video file itself*, not the webpage containing the video. I tried to get the actual video link from the one you provided, not sure it is the right one.