### PR TITLE
style: :lipstick: change navbar font colour to white

### DIFF
--- a/_extensions/steno-aarhus/sdca-theme/theme.scss
+++ b/_extensions/steno-aarhus/sdca-theme/theme.scss
@@ -8,6 +8,7 @@ $font-family-sans-serif: "Montserrat", sans-serif !default;
 $headings-font-family: "Mukta", sans-serif !default;
 $primary: #004452;
 $navbar-bg: #004452;
+$navbar-fg: white;
 
 /*-- scss:rules --*/
 


### PR DESCRIPTION
Hej Tina! 

Jeg har lige lavet en PR i stedet. Så kan du lige review og merge 😉 

Så har jeg ændret farven på teksten (og ikonerne) i navigationsbaren i toppen. 

Jeg gik ind på [Quartos dokumentatation](https://quarto.org/docs/output-formats/html-themes.html#navigation) og fandt variablen, der skulle sættes.